### PR TITLE
Update Jenkins example script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ can be pulled down from a repository and then ran by Jenkins.
     minimart web --host=$BUCKET_NAME
 
     echo Syncing web site up to s3://$BUCKET_NAME
-    aws s3 sync web s3://$BUCKET_NAME --acl public-read --exclude
+    aws s3 sync web s3://$BUCKET_NAME --size-only --acl public-read --exclude
     "web/universe"
     aws s3 cp web/universe s3://$BUCKET_NAME --acl public-read
 


### PR DESCRIPTION
Example jenkins job showing upload to S3, deletes local cookbooks and thus next run they'll have different timestamps causing "aws s3 sync" command to upload them again. Using --size-only option will let sync ignore the timedate stamps and only update changed cookbooks

from http://docs.aws.amazon.com/cli/latest/reference/s3/sync.html
--size-only (boolean) Makes the size of each key the only criteria used to decide whether to sync from source to destination.

(Should help with https://github.com/electric-it/minimart/issues/10)