### PR TITLE
Exposes source_url and issues_url of cookbook

### DIFF
--- a/lib/minimart/cookbook.rb
+++ b/lib/minimart/cookbook.rb
@@ -19,7 +19,7 @@ module Minimart
       new (Ridley::Chef::Cookbook.from_path(path))
     end
 
-    # @param [Ridley::Chef::Cookbok] raw_cookbook
+    # @param [Ridley::Chef::Cookbook] raw_cookbook
     def initialize(raw_cookbook)
       @raw_cookbook = raw_cookbook
     end
@@ -52,6 +52,18 @@ module Minimart
     # @return [String]
     def maintainer
       metadata.maintainer
+    end
+
+    # Get the source url of the cookbook
+    # @return [String]
+    def source_url
+      metadata.source_url
+    end
+
+    # Get the issues url of the cookbook
+    # @return [String]
+    def issues_url
+      metadata.issues_url
     end
 
     # Get the path to the cookbook on the file system
@@ -112,7 +124,9 @@ module Minimart
         url:            cookbook_path(self),
         downloaded_at:  downloaded_at,
         download_date:  download_date,
-        platforms:      normalized_platforms
+        platforms:      normalized_platforms,
+        source_url:     source_url,
+        issues_url:     issues_url
       }
     end
 

--- a/spec/fixtures/sample_cookbook/metadata.rb
+++ b/spec/fixtures/sample_cookbook/metadata.rb
@@ -5,5 +5,7 @@ license          'All rights reserved'
 description      'Installs/Configures sample_cookbook'
 long_description 'Installs/Configures sample_cookbook'
 version          '1.2.3'
+source_url       'https://github.com/electric-it/minimart'
+issues_url       'https://github.com/electric-it/minimart/issues'
 
 depends 'yum', '> 3.0.0'

--- a/spec/lib/minimart/cookbook_spec.rb
+++ b/spec/lib/minimart/cookbook_spec.rb
@@ -31,6 +31,16 @@ describe Minimart::Cookbook do
     it { is_expected.to eq 'MadGlory' }
   end
 
+  describe '#source_url' do
+    subject { cookbook.source_url }
+    it { is_expected.to eq 'https://github.com/electric-it/minimart'}
+  end
+
+  describe '#issues_url' do
+    subject { cookbook.issues_url }
+    it { is_expected.to eq 'https://github.com/electric-it/minimart/issues'}
+  end
+
   describe '#path' do
     subject { cookbook.path }
     it { is_expected.to eq Pathname.new('spec/fixtures/sample_cookbook') }

--- a/web/_assets/stylesheets/main.css
+++ b/web/_assets/stylesheets/main.css
@@ -302,6 +302,12 @@ form {
   width: 100%;
   margin-top: 20px; }
 
+.detail-sidebar__halfbutton {
+  width: 49%;
+  font-size: 14px;
+  margin-top: 20px;
+}
+
 /* Feature blocks */
 .feature-block {
   padding-top: 90px;

--- a/web/templates/cookbook_show.erb
+++ b/web/templates/cookbook_show.erb
@@ -76,6 +76,12 @@
       <dd><i class="icon-<%= platform_key %>" title="<%= description %>"></i></dd>
     <% end %>
   </dl>
+  <% unless cookbook.source_url.empty? %>
+  <a href="<%= cookbook.source_url %>" class="button detail-sidebar__halfbutton">Source</a>
+  <% end %>
+  <% unless cookbook.issues_url.empty? %>
+  <a href="<%= cookbook.issues_url %>" class="button detail-sidebar__halfbutton">Issues</a>
+  <% end %>
   <a href="<%= cookbook_download_path(cookbook) %>" class="button detail-sidebar__button">Download</a>
 </div>
 


### PR DESCRIPTION
Resolves #29 

So Ridley is setting these as [empty strings](https://github.com/berkshelf/ridley/commit/598c81b2fb08a849d390738947eca8394db5e025), thus the ugly `empty` calls.

![ui](https://gist.githubusercontent.com/ge1st/2eca19ba543da90dcccd/raw/b117bbba73023ad9b6204820526318d56fcd5ff0/ui.png)
The cookbook detail now looks like ^^. Design guidance appreciated.

Anything I miss? Also didn't commit the minified css. Want me to?