### PR TITLE
Cookbook Caching

### DIFF
--- a/lib/minimart/cli.rb
+++ b/lib/minimart/cli.rb
@@ -87,6 +87,7 @@ YML
       desc:    'Flag to determine whether or not to generate HTML output along with the universe endpoint.'
 
     option :clean_cookbooks,
+      type: :boolean,
       default: true,
       desc: 'Flag to determine whether or not existing cookbook packages are deleted and recreated'
     # Generate a web interface to download any mirrored cookbooks.

--- a/lib/minimart/cli.rb
+++ b/lib/minimart/cli.rb
@@ -86,6 +86,9 @@ YML
       default: true,
       desc:    'Flag to determine whether or not to generate HTML output along with the universe endpoint.'
 
+    option :clean_cookbooks,
+      default: true,
+      desc: 'Flag to determine whether or not existing cookbook packages are deleted and recreated'
     # Generate a web interface to download any mirrored cookbooks.
     def web
       Minimart::Commands::Web.new(options).execute!

--- a/lib/minimart/commands/web.rb
+++ b/lib/minimart/commands/web.rb
@@ -17,17 +17,21 @@ module Minimart
       # @return [Boolean] Determine whether or not to generate HTML output
       attr_reader :can_generate_html
 
+      # @return [Boolean] Determine whether or not to clean the cookbook_files folder and recreate
+      attr_reader :clean_cookbooks
 
       # @param [Hash] opts
       # @option opts [String] :inventory_directory The directory that the inventory is stored in.
       # @option opts [String] :web_directory The directory to store the web output.
       # @option opts [String] :host The web endpoint where Minimart will be hosted.
       # @option opts [Boolean] :can_generate_html Determine whether or not to generate HTML output
+      # @option opts [Boolean] :clean_cookbooks Determine whether or not to clean the cookbook_files folder and recreate
       def initialize(opts = {})
         @inventory_directory = File.expand_path(opts[:inventory_directory])
         @web_directory       = File.expand_path(opts[:web_directory])
         @web_endpoint        = opts[:host]
         @can_generate_html   = opts.fetch(:html, true)
+        @clean_cookbooks     = opts.fetch(:clean_cookbooks, true)
       end
 
       # Generate the web output.
@@ -52,7 +56,9 @@ module Minimart
         generator = Minimart::Web::UniverseGenerator.new(
           web_directory: web_directory,
           endpoint:      web_endpoint,
-          cookbooks:     cookbooks)
+          cookbooks:     cookbooks,
+          clean_cookbooks: clean_cookbooks
+        )
 
         generator.generate
       end
@@ -64,7 +70,9 @@ module Minimart
 
         generator = Minimart::Web::HtmlGenerator.new(
           web_directory: web_directory,
-          cookbooks:     cookbooks)
+          cookbooks:     cookbooks,
+          clean_cookbooks: clean_cookbooks
+        )
 
         generator.generate
       end

--- a/lib/minimart/inventory_requirement/base_requirement.rb
+++ b/lib/minimart/inventory_requirement/base_requirement.rb
@@ -60,7 +60,10 @@ module Minimart
       # Convert the requirement to a Hash.
       # @return [Hash]
       def to_hash
-        {}
+        {
+            :metadata_version => '2.0', #metadata document version.
+            :name => @name
+        }
       end
 
       # Determine if a cookbook in the inventory has metadata matching this requirement
@@ -68,7 +71,12 @@ module Minimart
       #   in the inventory.
       # @return [Boolean] Defaults to true
       def matching_source?(metadata)
-        return true
+        if metadata.has_key?('metadata_version') && metadata['metadata_version'] == '2.0'
+          metadata['name'] == @name &&
+            metadata['version'] == @version_requirement
+        else
+          true
+        end
       end
 
       private

--- a/lib/minimart/inventory_requirement/git_requirement.rb
+++ b/lib/minimart/inventory_requirement/git_requirement.rb
@@ -56,9 +56,16 @@ module Minimart
       #   in the inventory.
       # @return [Boolean] Defaults to true
       def matching_source?(metadata)
-        metadata['source_type'] == 'git' &&
-          metadata['commitish_type'] == commitish_type.to_s &&
-          (metadata['commitish_type'] == 'ref' ? true : metadata['commitish'] == commitish.to_s)
+        if metadata.has_key?('metadata_version') && metadata['metadata_version'] == '2.0'
+          metadata['source_type'] == 'git' &&
+            metadata['location'] == @location &&
+            metadata['commitish_type'] == commitish_type.to_s &&
+            (metadata['commitish_type'] == 'ref' ? true : metadata['commitish'] == commitish.to_s)
+        else
+          metadata['source_type'] == 'git' &&
+            metadata['commitish_type'] == commitish_type.to_s &&
+            (metadata['commitish_type'] == 'ref' ? true : metadata['commitish'] == commitish.to_s)
+        end
       end
 
       private

--- a/lib/minimart/inventory_requirement/local_path_requirement.rb
+++ b/lib/minimart/inventory_requirement/local_path_requirement.rb
@@ -25,12 +25,18 @@ module Minimart
       # @return [Hash]
       def to_hash
         result = super
+        result[:path] = @path
         result[:source_type] = :local_path
         result
       end
 
       def matching_source?(metadata)
-        metadata['source_type'] == 'local_path'
+        if metadata.has_key?('metadata_version') && metadata['metadata_version'] == '2.0'
+          metadata['source_type'] == 'local_path' &&
+            metadata['path'] == @path
+        else
+          metadata['source_type'] == 'local_path'
+        end
       end
 
       private

--- a/lib/minimart/mirror/download_metadata.rb
+++ b/lib/minimart/mirror/download_metadata.rb
@@ -40,6 +40,10 @@ module Minimart
         metadata[key] if metadata
       end
 
+      def has_key?(key)
+        (metadata ? metadata.has_key?(key) : false)
+      end
+
       private
 
       def parse_file

--- a/lib/minimart/mirror/inventory_builder.rb
+++ b/lib/minimart/mirror/inventory_builder.rb
@@ -1,3 +1,4 @@
+require 'ridley'
 module Minimart
   module Mirror
 

--- a/lib/minimart/mirror/inventory_builder.rb
+++ b/lib/minimart/mirror/inventory_builder.rb
@@ -1,4 +1,3 @@
-require 'ridley'
 module Minimart
   module Mirror
 
@@ -35,6 +34,12 @@ module Minimart
       def install_cookbooks_with_explicit_location
         inventory_requirements.each_with_explicit_location do |requirement|
           begin
+            requirement_cookbook = local_store.cookbook_for_requirement(requirement)
+            if requirement_cookbook
+              Configuration.output.puts_yellow("cookbook already installed: #{requirement_cookbook}.")
+              next
+            end
+            
             requirement.fetch_cookbook do |cookbook|
               validate_cookbook_against_local_store(cookbook, requirement)
               add_artifact_to_graph(cookbook)

--- a/lib/minimart/mirror/local_store.rb
+++ b/lib/minimart/mirror/local_store.rb
@@ -16,14 +16,19 @@ module Minimart
       def initialize(directory_path)
         @directory_path = directory_path
         @cookbooks      = {}
+        @metadata = {}
 
         load_local_inventory
+
       end
 
       # :nodoc:
       def add_cookbook_to_store(name, version)
         cookbooks[name] ||= []
         cookbooks[name] << version
+
+        metadata[name] ||= {}
+        metadata[name][version] = local_path_for("#{name}-#{version}")
       end
 
       # Copy a given cookbook to the local store, and record any metadata
@@ -45,6 +50,28 @@ module Minimart
           cookbooks[cookbook_name].include?(cookbook_version))
       end
 
+      def cookbook_for_requirement(requirement)
+        #we dont handle caching for anything other than git requirements in this function.
+        return nil unless requirement.is_a?(InventoryRequirement::GitRequirement)
+        # if this is a branch, we can't assume that the commit is the same (remote could have changed)
+        return nil if requirement.branch
+
+        @metadata.each{ |cookbook, versions|
+
+          versions.each{ |version, lazy_metadata|
+            #lazy populate the metadata
+            if(lazy_metadata.is_a?(String))
+              lazy_metadata = Minimart::Mirror::DownloadMetadata.new(lazy_metadata)
+            end
+
+            if requirement.matching_source?(lazy_metadata)
+              return "#{cookbook}-#{version}"
+            end
+          }
+        }
+        return nil
+      end
+
       # Validate that a new resolved requirement is not in the local store
       # with different requirements. If we download two different branches
       # of the same cookbook and they both resolve to the same version, then we
@@ -64,6 +91,7 @@ module Minimart
       private
 
       attr_reader :cookbooks
+      attr_reader :metadata
 
       def copy_cookbook(source, destination)
         FileUtils.rm_rf(destination) if Dir.exists?(destination)

--- a/lib/minimart/mirror/source_cookbook.rb
+++ b/lib/minimart/mirror/source_cookbook.rb
@@ -51,6 +51,9 @@ module Minimart
       # @return [Hash]
       def to_hash
         {
+          metadata_version: '2.0',
+          name: @name,
+          version: @version,
           source_type: location_type,
           location:    location_path
         }

--- a/lib/minimart/web/cookbook_show_page_generator.rb
+++ b/lib/minimart/web/cookbook_show_page_generator.rb
@@ -10,12 +10,15 @@ module Minimart
       # @return [Minimart::Web::Cookbooks] the cookbooks to generate show pages for
       attr_reader :cookbooks
 
+      attr_reader :clean_cookbooks
+
       # @param [Hash] opts
       # @option opts [String] :web_directory The directory to put any generated HTML in
       # @option opts [String] :cookbooks The cookbooks to generate show pages for
       def initialize(opts = {})
         @web_directory = opts[:web_directory]
         @cookbooks     = opts[:cookbooks]
+        @clean_cookbooks = opts.fetch(:clean_cookbooks, true)
       end
 
       # Generate the HTML!
@@ -28,8 +31,9 @@ module Minimart
       private
 
       def clean_web_cookbooks_directory
-        return unless Dir.exists?(cookbooks_directory)
-        FileUtils.remove_entry(cookbooks_directory)
+        if Dir.exists?(cookbooks_directory) && @clean_cookbooks
+          FileUtils.remove_entry(cookbooks_directory)
+        end
       end
 
       def make_web_cookbooks_directory
@@ -39,7 +43,7 @@ module Minimart
       def create_html_files
         cookbooks.each do |cookbook_name, versions|
           versions.each do |cookbook|
-            write_to_file(file(cookbook), template_content(cookbook, versions))
+            write_to_file(file(cookbook), template_content(cookbook, versions)) unless File.exists?(file(cookbook))
           end
         end
       end

--- a/lib/minimart/web/html_generator.rb
+++ b/lib/minimart/web/html_generator.rb
@@ -12,7 +12,7 @@ module Minimart
     class HtmlGenerator
       include Minimart::Web::TemplateHelper
 
-      attr_reader :web_directory, :cookbooks
+      attr_reader :web_directory, :cookbooks, :clean_cookbooks
 
       # @param [Hash] opts
       # @option opts [String] :web_directory The directory to put any generated HTML in
@@ -20,6 +20,7 @@ module Minimart
       def initialize(opts = {})
         @web_directory = opts[:web_directory]
         @cookbooks     = opts[:cookbooks]
+        @clean_cookbooks = opts.fetch(:clean_cookbooks, true)
       end
 
       # Generate any HTML!
@@ -68,7 +69,8 @@ module Minimart
       def generate_cookbook_show_pages
         CookbookShowPageGenerator.new(
           web_directory: web_directory,
-          cookbooks:     cookbooks).generate
+          cookbooks:     cookbooks,
+          clean_cookbooks: clean_cookbooks).generate
       end
 
     end

--- a/lib/minimart/web/universe_generator.rb
+++ b/lib/minimart/web/universe_generator.rb
@@ -23,10 +23,12 @@ module Minimart
       # @option opts [String] web_directory The directory to put the universe.json file in
       # @option opts [String] endpoint The base URL to use to build paths for cookbook files.
       # @option opts [Minimart::Web::Cookbooks] cookbooks The cookbooks to build a universe for
+      # @option opts [Boolean] clean_cookbooks Determines if we should clean the cookbook_files folder and recreate cookbook packages
       def initialize(opts = {})
         @web_directory = opts[:web_directory]
         @endpoint      = opts[:endpoint]
         @cookbooks     = opts[:cookbooks]
+        @clean_cookbooks = opts.fetch(:clean_cookbooks, true)
         @universe      = {}
       end
 
@@ -41,8 +43,9 @@ module Minimart
       private
 
       def clean_existing_cookbook_files
-        return unless Dir.exists?(cookbook_files_directory)
-        FileUtils.remove_entry(cookbook_files_directory)
+        if Dir.exists?(cookbook_files_directory) && @clean_cookbooks
+          FileUtils.remove_entry(cookbook_files_directory)
+        end
       end
 
       def make_cookbook_files_directory
@@ -51,8 +54,10 @@ module Minimart
 
       def create_universe
         cookbooks.individual_cookbooks.each do |cookbook|
-          make_cookbook_directory(cookbook)
-          generate_archive_file(cookbook)
+          unless Dir.exists?(archive_directory(cookbook))
+            make_cookbook_directory(cookbook)
+            generate_archive_file(cookbook)
+          end
           add_cookbook_to_universe(cookbook)
         end
       end

--- a/spec/lib/minimart/cli_spec.rb
+++ b/spec/lib/minimart/cli_spec.rb
@@ -69,7 +69,8 @@ describe Minimart::Cli do
         'web_directory'       => './web',
         'inventory_directory' => './inventory',
         'host'                => 'http://example.com',
-        'html'                => true).and_return command_double
+        'html'                => true,
+        'clean_cookbooks'     => true).and_return command_double
 
       Minimart::Cli.start %w[web --host=http://example.com]
     end
@@ -79,7 +80,8 @@ describe Minimart::Cli do
         'web_directory'       => './my-web',
         'inventory_directory' => './my-inventory',
         'host'                => 'http://example.com',
-        'html'                => false).and_return command_double
+        'html'                => false,
+        'clean_cookbooks'     => true).and_return command_double
 
       Minimart::Cli.start %w[
         web

--- a/spec/lib/minimart/commands/web_spec.rb
+++ b/spec/lib/minimart/commands/web_spec.rb
@@ -44,6 +44,7 @@ describe Minimart::Commands::Web do
       expect(Minimart::Web::UniverseGenerator).to receive(:new).with(
         web_directory: subject.web_directory,
         endpoint: subject.web_endpoint,
+        clean_cookbooks: true,
         cookbooks: an_instance_of(Minimart::Web::Cookbooks)).and_return generator_double
 
       subject.execute!
@@ -52,7 +53,8 @@ describe Minimart::Commands::Web do
     it 'should generate the static HTML files' do
       expect(Minimart::Web::HtmlGenerator).to receive(:new).with(
         web_directory: subject.web_directory,
-        cookbooks: an_instance_of(Minimart::Web::Cookbooks)).and_return generator_double
+        cookbooks: an_instance_of(Minimart::Web::Cookbooks),
+        clean_cookbooks: true).and_return generator_double
 
       subject.execute!
     end

--- a/spec/lib/minimart/mirror/local_store_spec.rb
+++ b/spec/lib/minimart/mirror/local_store_spec.rb
@@ -61,4 +61,39 @@ describe Minimart::Mirror::LocalStore do
     end
   end
 
+  describe '#cookbook_for_requirement' do
+    let(:sample_cookbook_path) { 'spec/fixtures/sample_cookbook' }
+    it 'should return cookbook name when requirement matches existing cookbook' do
+      subject.add_cookbook_from_path(sample_cookbook_path, {
+                                                             'source_type'    => 'git',
+                                                             'location'       => 'spec/fixtures/sample_cookbook',
+                                                             'commitish_type' => 'tag',
+                                                             'commitish'      => 'v1.2.3'})
+
+      requirement = Minimart::InventoryRequirement::GitRequirement.new('sample_cookbook', {
+                                                                           :tag => 'v1.2.3',
+                                                                           :location => 'spec/fixtures/sample_cookbook',
+                                                                           :version_requirement => '1.2.3'
+                                                                                              })
+
+      expect(subject.cookbook_for_requirement(requirement)).to eq 'sample_cookbook-1.2.3'
+    end
+
+    it 'should return nil when requirement does not match any existing cookbook' do
+      subject.add_cookbook_from_path(sample_cookbook_path, {
+                                                             'source_type'    => 'git',
+                                                             'location'       => 'spec/fixtures/sample_cookbook',
+                                                             'commitish_type' => 'tag',
+                                                             'commitish'      => 'v1.2.3'})
+
+      requirement = Minimart::InventoryRequirement::GitRequirement.new('sample_cookbook', {
+                                                                                            :branch => 'feature_branch',
+                                                                                            :location => 'spec/fixtures/sample_cookbook',
+                                                                                            :version_requirement => '1.2.3'
+                                                                                        })
+
+      expect(subject.cookbook_for_requirement(requirement)).to eq nil
+    end
+  end
+
 end


### PR DESCRIPTION
Hey @tapickell @richardardrichard @berniedurfee-ge 
This is the followup PR to #35 and fixes #34 

Basically I needed a way to generate a minimart for ~300 different cookbooks with ~4000 tagged versions. Currently minimart takes almost __40 minutes__ to do that, primarily because of 2 things:

- git cookbooks arn't cached, and are downloaded again every time. 
- the `tar.gz` file for each cookbook version is regenerated each time by the web command. 
- because the `tar.gz` file is created new each time, the AWS sync command re-uploads everything.

First I modified the minimart InventoryBuilder and LocalStore so that it keeps track of the metadata files for each cookbook that it sees in the inventory_directory. Then when a explicit_location cookbook is added via the inventory file, it checks if the cookbook already exists, and if so, does not clone and fetch the cookbook again. 

To do this I had to make changes to the metadata files, `.minimart.json`. I added a metadata_version number to all new files because the changes I made to the `matching_source?` function arn't really backwards compatible. If the new metadata_version key is present, it uses the new logic, otherwise it falls back to the previous logic. 

Then I modified the Web command such that you can optionally specify if you want the `cookbook_directory` to be cleaned on each run. By default this value is true (which is how it was before, but if you use `--no-clean-cookbooks` in the CLI, the Web command will check if a `tar.gz` already exists for a package before generating it. 

After making these changes, I was able to bring down the build and deploy time to __less than 2 minutes__, which makes it perfect for incremental changes to a large cookbook repo. 

---

Having said that, there is still a single issue left with this PR. There's a single test which continues to fail, something that I haven't figured out how to fix. I'd appreciate any help :)



