### PR TITLE
Fixes issue #47 with required ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: ruby
 cache: bundler
 rvm:
+  - 2.3.1
   - 2.2.3
   - 2.1.7
+script:
+  - bundle exec rake
+  - bundle exec rake install
 notifications:
   flowdock:
     secure: s2EpKpFFZJL51GChkIM/B8CpoiAvj56aYp7iSfKcD5aZvdBRssXXt9i3t39TA/hD8NkWfM07eVbhL3tGAv2GcXhTOlXZSoljzGdzFdGROZZd4asd1pLK8VuJTQrEKPDfKp/+XsIfbfOrTFf19qhBAfk5A0TRUXVMITiMkVIo1D4=

--- a/lib/minimart/version.rb
+++ b/lib/minimart/version.rb
@@ -1,3 +1,3 @@
 module Minimart
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end

--- a/minimart.gemspec
+++ b/minimart.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://electric-it.github.io/minimart/'
   spec.license       = 'Apache License, v2.0'
 
-  spec.required_ruby_version = ['~> 2.1', '~> 2.2']
+  spec.required_ruby_version = '>= 2.1'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
This resolves issue #47 where the required ruby version was preventing
install on Ruby 2.1.X but worked on 2.2.X and 2.3.X
I am not 100% why this didn't work originally but would rather have it
start from the lowest supported Ruby version to the latest version.
I have testing this installing with versions:
   ruby-2.0.0-p648 [ x86_64 ]
   ruby-2.1.8 [ x86_64 ]
   ruby-2.2.3 [ x86_64 ]
   ruby-2.3.0 [ x86_64 ]
   ruby-2.3.1 [ x86_64 ]

Ruby 2.0.0 (EOL) fails all others succeed to install.
Todd Pickell @tapickell <tapickell@gmail.com>