### PR TITLE
Ruby 2.2 is required

### DIFF
--- a/minimart.gemspec
+++ b/minimart.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'http://electric-it.github.io/minimart/'
   spec.license       = 'Apache License, v2.0'
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
#57 switched minimart testing to ruby >= 2.2 and ridley dependency to 5, which require ruby 2.2